### PR TITLE
update linter rules and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,12 @@ linters:
     - misspell
     - rowserrcheck
     - errorlint
+    - unconvert
+    - sqlclosecheck
+    - noctx
+    - whitespace
+    - depguard
+    - containedctx
 linters-settings:
   exhaustive:
     default-signifies-exhaustive: true
@@ -26,7 +32,7 @@ linters-settings:
       # - G404
   govet:
     # report about shadowed variables
-    check-shadowing: false
+    check-shadowing: true
   errorlint:
     # Allow formatting of errors without %w
     errorf: false
@@ -40,9 +46,10 @@ linters-settings:
       - name: error-return
       - name: error-strings
       - name: error-naming
+      - name: exported
       - name: if-return
       - name: increment-decrement
-      # - name: var-naming
+      - name: var-naming
       - name: var-declaration
       - name: package-comments
       - name: range
@@ -68,13 +75,44 @@ linters-settings:
       - name: identical-branches
       - name: get-return
       # - name: flag-parameter
-      # - name: early-return
+      - name: early-return
       - name: defer
       - name: constant-logical-expr
       # - name: confusing-naming
       # - name: confusing-results
       - name: bool-literal-in-expr
       - name: atomic
+  depguard:
+    rules:
+      main:
+        list-mode: lax
+        deny:
+          - pkg: "cosmossdk.io/errors"
+            desc: Use the standard library instead
+          - pkg: "github.com/ethereum/go-ethereum"
+            desc: This is a chain-agnostic repo
+          - pkg: "github.com/go-gorm/gorm"
+            desc: Use github.com/jmoiron/sqlx directly instead
+          - pkg: "github.com/gofrs/uuid"
+            desc: Use github.com/google/uuid instead
+          - pkg: "github.com/pkg/errors"
+            desc: Use the standard library instead, for example https://pkg.go.dev/errors#Join
+          - pkg: "github.com/satori/go.uuid"
+            desc: Use github.com/google/uuid instead
+          - pkg: "github.com/test-go/testify/assert"
+            desc: Use github.com/stretchr/testify/assert instead
+          - pkg: "github.com/test-go/testify/mock"
+            desc: Use github.com/stretchr/testify/mock instead
+          - pkg: "github.com/test-go/testify/require"
+            desc: Use github.com/stretchr/testify/require instead
+          - pkg: "go.uber.org/multierr"
+            desc: Use the standard library instead, for example https://pkg.go.dev/errors#Join
+          - pkg: "gopkg.in/guregu/null.v1"
+            desc: Use gopkg.in/guregu/null.v4 instead
+          - pkg: "gopkg.in/guregu/null.v2"
+            desc: Use gopkg.in/guregu/null.v4 instead
+          - pkg: "gopkg.in/guregu/null.v3"
+            desc: Use gopkg.in/guregu/null.v4 instead
 issues:
   exclude-rules:
     - path: test

--- a/median/plugin.go
+++ b/median/plugin.go
@@ -117,14 +117,13 @@ func (c *chainReaderContract) LatestTransmissionDetails(ctx context.Context) (co
 
 	err = c.chainReader.GetLatestValue(ctx, contractName, "LatestTransmissionDetails", nil, &resp)
 	if err != nil {
-		if errors.Is(err, types.ErrNotFound) {
-			// If there's nothing transmitted yet, an implementation will not have emitted an event,
-			// or may not find details of a latest transmission on-chain if it's a function call.
-			// A zeroed out latestTransmissionDetailsResponse tells later parts of the system that there's no data yet.
-			c.lggr.Warn("LatestTransmissionDetails not found", "err", err)
-		} else {
+		if !errors.Is(err, types.ErrNotFound) {
 			return
 		}
+		// If there's nothing transmitted yet, an implementation will not have emitted an event,
+		// or may not find details of a latest transmission on-chain if it's a function call.
+		// A zeroed out latestTransmissionDetailsResponse tells later parts of the system that there's no data yet.
+		c.lggr.Warn("LatestTransmissionDetails not found", "err", err)
 	}
 
 	// Depending on if there is a LatestAnswer or not, and the implementation of the ChainReader,
@@ -141,14 +140,13 @@ func (c *chainReaderContract) LatestRoundRequested(ctx context.Context, lookback
 
 	err = c.chainReader.GetLatestValue(ctx, contractName, "LatestRoundRequested", nil, &resp)
 	if err != nil {
-		if errors.Is(err, types.ErrNotFound) {
-			// If there's nothing on-chain yet, an implementation will not have emitted an event,
-			// or may not find details of a latest transmission on-chain if it's a function call.
-			// A zeroed out LatestRoundRequested tells later parts of the system that there's no data yet.
-			c.lggr.Warn("LatestRoundRequested not found", "err", err)
-		} else {
+		if !errors.Is(err, types.ErrNotFound) {
 			return
 		}
+		// If there's nothing on-chain yet, an implementation will not have emitted an event,
+		// or may not find details of a latest transmission on-chain if it's a function call.
+		// A zeroed out LatestRoundRequested tells later parts of the system that there's no data yet.
+		c.lggr.Warn("LatestRoundRequested not found", "err", err)
 	}
 
 	return resp.ConfigDigest, resp.Epoch, resp.Round, nil


### PR DESCRIPTION
This was started in pursuit of https://smartcontract-it.atlassian.net/browse/BCF-3203 but there were no instances of `containedctx` violations. The ruleset was out of date besides, and updating everything only flagged two issues, which are fixed.