### PR TITLE
go.mod cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
+module github.com/smartcontractkit/chainlink-feeds
+
 go 1.22
 
 toolchain go1.22.6
@@ -83,8 +85,3 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// until merged upstream: https://github.com/mwitkow/grpc-proxy/pull/69
-replace github.com/mwitkow/grpc-proxy => github.com/smartcontractkit/grpc-proxy v0.0.0-20230731113816-f1be6620749f
-
-module github.com/smartcontractkit/chainlink-feeds

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/hashicorp/go-plugin v1.6.2-0.20240829161738-06afb6d7ae99
-	github.com/smartcontractkit/chainlink-common v0.2.2-0.20240910115520-d5c8c953d2c3
+	github.com/smartcontractkit/chainlink-common v0.2.2-0.20240913100429-aa383c8c4694
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c
 	github.com/stretchr/testify v1.9.0
 )

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.2.0 h1:WCcC4vZDS1tYNxjWlwRJZQy28r8CM
 github.com/santhosh-tekuri/jsonschema/v5 v5.2.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
-github.com/smartcontractkit/chainlink-common v0.2.2-0.20240910115520-d5c8c953d2c3 h1:juQEx1cD1XcJNgqXrSEVZ2uZ97S76pxo5DRfRQIsdLM=
-github.com/smartcontractkit/chainlink-common v0.2.2-0.20240910115520-d5c8c953d2c3/go.mod h1:D/qaCoq0SxXzg5NRN5FtBRv98VBf+D2NOC++RbvvuOc=
+github.com/smartcontractkit/chainlink-common v0.2.2-0.20240913100429-aa383c8c4694 h1:yhGECtHtzGIIFhEBcoCiMsF4NrZhRZ7XLNt5nI3glFg=
+github.com/smartcontractkit/chainlink-common v0.2.2-0.20240913100429-aa383c8c4694/go.mod h1:sjiiPwd4KsYOCf68MwL86EKphdXeT66EY7j53WH5DCc=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 h1:12ijqMM9tvYVEm+nR826WsrNi6zCKpwBhuApq127wHs=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7/go.mod h1:FX7/bVdoep147QQhsOPkYsPEXhGZjeYx6lBSaSXtZOA=
 github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c h1:lIyMbTaF2H0Q71vkwZHX/Ew4KF2BxiKhqEXwF8rn+KI=


### PR DESCRIPTION
Move module  back to top, remove unecessary replace, update common to a default branch version.